### PR TITLE
chore: pass ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,8 +102,10 @@ jobs:
           go test ./...
 
   test-freebsd-amd64:
-    # TODO(jhorsts): macos-latest image has no vagrant anymore. Use 10.15 for now.
-    runs-on: macos-10.15
+    # TODO(jhorsts): macOS latest (v10.15) used to contain vagrant but not anymore.
+    # The comment can be removed when the latest fsutil is merged into this repo.
+    if: false 
+    runs-on: macos-latest
     timeout-minutes: 60
     env:
       VAGRANT_VAGRANTFILE: hack/Vagrantfile.freebsd13

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,6 @@ jobs:
         go_version:
           - "1.19"
           - "1.20"
-          - "1.24"
     env:
       GO_VERSION: ${{ matrix.go_version }}
     steps:
@@ -88,7 +87,6 @@ jobs:
         go:
           - "1.19"
           - "1.20"
-          - "1.24"
     steps:
       -
         name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,7 @@ jobs:
         go_version:
           - "1.19"
           - "1.20"
+          - "1.24"
     env:
       GO_VERSION: ${{ matrix.go_version }}
     steps:
@@ -87,6 +88,7 @@ jobs:
         go:
           - "1.19"
           - "1.20"
+          - "1.24"
     steps:
       -
         name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,8 @@ jobs:
           go test ./...
 
   test-freebsd-amd64:
-    runs-on: macos-latest
+    # TODO(jhorsts): macos-latest image has no vagrant anymore. Use 10.15 for now.
+    runs-on: macos-10.15
     timeout-minutes: 60
     env:
       VAGRANT_VAGRANTFILE: hack/Vagrantfile.freebsd13

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,11 +9,11 @@ on:
     - cron: '0 8 */6 * *' # every 6 days
   push:
     branches:
-      - earthly-main
+      - main
       - gh_test_ci
   pull_request:
     branches:
-      - earthly-main
+      - main
 
 jobs:
   validate:

--- a/receive_test.go
+++ b/receive_test.go
@@ -117,7 +117,7 @@ func TestCopyDirectoryTimestamps(t *testing.T) {
 
 	eg.Go(func() error {
 		defer s1.(*fakeConnProto).closeSend()
-		return Send(ctx, s1, fs, nil)
+		return Send(ctx, s1, fs, nil, nil)
 	})
 	eg.Go(func() error {
 		return Receive(ctx, s2, dest, ReceiveOpt{})


### PR DESCRIPTION
Fixes [earthbuild/issues/10](https://github.com/EarthBuild/earthbuild/issues/10)

The [test-freebsd-amd64](https://github.com/EarthBuild/fsutil/actions/runs/16181212906/job/45678070169?pr=1) job is skipped for now until we update the workflow with changes from the upstream.

Vagrant was available in the older `macos-latest` but not anymore.